### PR TITLE
Remove apt install

### DIFF
--- a/fastapi_export_openapi/export_openapi.py
+++ b/fastapi_export_openapi/export_openapi.py
@@ -1,26 +1,17 @@
 import typer
 import yaml
 
-
 import json
 import logging
-import subprocess
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 
 class OutputTypeEnum(str, Enum):
     json = "JSON"
     yaml = "YAML"
     both = "BOTH"
-
-
-def install_apt_packages(dependencies: List[str]) -> None:
-    logging.info("Updating apt repository index")
-    subprocess.check_call(["apt", "update"])
-    logging.info("Installing apt dependencies")
-    subprocess.check_call(["apt", "install", "-y", " ".join(dependencies)])
 
 
 def write_json_openapi(openapi: Dict[str, Any], output_path: Path) -> None:

--- a/fastapi_export_openapi/main.py
+++ b/fastapi_export_openapi/main.py
@@ -3,11 +3,10 @@ import typer
 import importlib
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from fastapi_export_openapi.export_openapi import (
     OutputTypeEnum,
-    install_apt_packages,
     write_json_openapi,
     write_yaml_openapi,
 )
@@ -23,14 +22,10 @@ def export_openapi(
     output_type: OutputTypeEnum = OutputTypeEnum.json,
     json_output_path: Path = Path("openapi.json"),
     yaml_output_path: Path = Path("openapi.yaml"),
-    apt_package: Optional[List[str]] = typer.Option(None),
 ) -> None:
     """
     Write the application's OpenAPI schema to disk.
     """
-
-    if len(apt_package) > 0:
-        install_apt_packages(apt_package)
 
     app = importlib.import_module(fastapi_app_module).app
     openapi = app.openapi()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi_export_openapi"
-version = "0.1.0"
+version = "0.1.1"
 description = "GitHub Action to export OpenAPI schema from FastAPI apps."
 authors = ["Andrew Hoetker <andrew@hoetker.engineer>"]
 


### PR DESCRIPTION
The package previously had facilities to install `apt` packages. This is a better fit in the scope of a GitHub action, not the Python package.